### PR TITLE
Use scalacss.devOrProdDefaults

### DIFF
--- a/src/main/scala/app/App.scala
+++ b/src/main/scala/app/App.scala
@@ -3,9 +3,8 @@ package app
 import app.components.Main
 
 import scala.scalajs.js.JSApp
-import org.scalajs.dom
-import dom.document
-import scalacss.DevDefaults._ // ProdDefaults for prod
+import org.scalajs.dom.document
+import CssSettings._
 import scalacss.ScalaCssReact._
 
 object App extends JSApp {

--- a/src/main/scala/app/Styles.scala
+++ b/src/main/scala/app/Styles.scala
@@ -1,6 +1,6 @@
 package app
 
-import scalacss.DevDefaults._ // ProdDefaults for prod
+import CssSettings._
 
 object Styles extends StyleSheet.Inline {
   import dsl._

--- a/src/main/scala/app/package.scala
+++ b/src/main/scala/app/package.scala
@@ -1,0 +1,6 @@
+package object app {
+
+  // This allows Scala.JS to choose dev settings during fastOptJS, and prod settings during fullOptJS.
+  val CssSettings = scalacss.devOrProdDefaults
+
+}


### PR DESCRIPTION
This allows Scala.JS to choose dev settings during fastOptJS, and prod settings during fullOptJS